### PR TITLE
1.fixbug:不通过代码而是配置设置横屏,解决某些机型设置横屏无效

### DIFF
--- a/idcardcamera/src/main/AndroidManifest.xml
+++ b/idcardcamera/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         <activity
             android:name=".camera.CameraActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
+            android:screenOrientation="landscape"
             android:theme="@android:style/Theme.Light.NoTitleBar.Fullscreen"/>
     </application>
 

--- a/idcardcamera/src/main/java/com/wildma/idcardcamera/camera/CameraActivity.java
+++ b/idcardcamera/src/main/java/com/wildma/idcardcamera/camera/CameraActivity.java
@@ -101,7 +101,6 @@ public class CameraActivity extends Activity implements View.OnClickListener {
     private void init() {
         setContentView(R.layout.activity_camera);
         mType = getIntent().getIntExtra(IDCardCamera.TAKE_TYPE, 0);
-        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
         initView();
         initListener();
     }


### PR DESCRIPTION
=============================
refer:
x + width must be <= bitmap.width()

com.wildma.idcardcamera.camera.CameraActivity.cropImage(CameraActivity.java:235)